### PR TITLE
Fixed "partially matched" warning

### DIFF
--- a/faoswsFlag/R/weight2flag.R
+++ b/faoswsFlag/R/weight2flag.R
@@ -9,6 +9,6 @@
 
 weight2flag = function(flagObservationWeight,
                        flagTable = faoswsFlagTable){
-    index = match(flagObservationWeight, flagTable$flagObservationWeight)
+    index = match(flagObservationWeight, flagTable$flagObservationWeights)
     as.character(flagTable$flagObservationStatus[index])
 }


### PR DESCRIPTION
The column name of faoswsFlagTable is "flagObservationWeights".  Using "flagObservationWeight" causes a warning whenever this function is called.
